### PR TITLE
Fixed chart column values bug.

### DIFF
--- a/src/column-directive.js
+++ b/src/column-directive.js
@@ -45,7 +45,13 @@ angular.module('gridshore.c3js.chart')
  */
 function ChartColumn () {
     var columnLinker = function (scope, element, attrs, chartCtrl) {
-        var column = attrs.columnValues.split(",");
+        var column = attrs.columnValues;
+
+        if (column[0] == '[' && column.slice(-1) == ']') {
+            column = column.slice(1, -1);
+        }
+
+        column = column.split(",");
         column.unshift(attrs.columnId);
         chartCtrl.addColumn(column, attrs.columnType, attrs.columnName, attrs.columnColor);
     };

--- a/src/column-directive.js
+++ b/src/column-directive.js
@@ -47,7 +47,7 @@ function ChartColumn () {
     var columnLinker = function (scope, element, attrs, chartCtrl) {
         var column = attrs.columnValues;
 
-        if (column[0] == '[' && column.slice(-1) == ']') {
+        if (column[0] == "[" && column.slice(-1) == "]") {
             column = column.slice(1, -1);
         }
 


### PR DESCRIPTION
This PR fixes a bug where the first and last value for a line chart were never rendered. Because the `attrs.columnValues` contained brackets and these were not cleaned up.

The image shows the first and last values containing a bracket.

![screenshot 2015-09-03 20 17 21](https://cloud.githubusercontent.com/assets/64841/9666912/28682e70-5279-11e5-84f7-afaa829aa6be.png)
