### PR TITLE
Added color thresholds functionality to chart-color directive.

### DIFF
--- a/src/colors-directive.js
+++ b/src/colors-directive.js
@@ -14,15 +14,16 @@ angular.module('gridshore.c3js.chart')
  *   c3chart
  *
  * @param {String} color-pattern A string containing comma separated hex colors
+ * @param {String} thresholds A string containing comma separated numeric values
  *   
- *   {@link http://c3js.org/reference.html#color-pattern| c3js docs}
+ * {@link http://c3js.org/reference.html#color-pattern| c3js docs}
  * @param {Function} color-function Provide a function that receives the value to determine a color for that value.
  *
- *   {@link http://c3js.org/reference.html#data-color| c3js docs}
+ * {@link http://c3js.org/reference.html#data-color| c3js docs}
  *
  * @example
  * Usage:
- *   <chart-color color-pattern="..." color-function="..."/>
+ *   <chart-color color-pattern="..." color-function="..." thresholds="..."/>
  * 
  * Example:
  *   {@link http://jettro.github.io/c3-angular-directive/#examples}
@@ -36,6 +37,11 @@ function ChartColors () {
             chartCtrl.addColors(pattern.split(","));
         }
 
+        var thresholds = attrs.thresholds;
+        if(thresholds){
+            chartCtrl.addColorThresholds(thresholds.split(","));
+        }
+        
         if (attrs.colorFunction) {
             chartCtrl.addColorFunction(scope.colorFunction());
         }

--- a/src/controller.js
+++ b/src/controller.js
@@ -20,12 +20,12 @@ angular.module('gridshore.c3js.chart')
             $scope.xTick = null;
             $scope.yTick = null;
             $scope.names = null;
-            $scope.colors = null;
             $scope.grid = null;
             $scope.legend = null;
             $scope.tooltip = null;
             $scope.chartSize = null;
             $scope.colors = null;
+            $scope.colorThresholds = null;
             $scope.gauge = null;
             $scope.jsonKeys = null;
             $scope.groups = null;
@@ -134,6 +134,12 @@ angular.module('gridshore.c3js.chart')
             }
             if ($scope.colors != null) {
                 config.color = {"pattern": $scope.colors};
+                config.color = {
+                    "pattern": $scope.colors,
+                    "threshold" : {
+                        "values" : $scope.colorThresholds
+                    }
+                };
             }
             if ($scope.gauge != null) {
                 config.gauge = $scope.gauge;
@@ -355,6 +361,15 @@ angular.module('gridshore.c3js.chart')
             $scope.colors = colors;
         };
 
+        this.addColorThresholds = function (thresholds) {
+            $scope.colorThresholds = thresholds;
+            if($scope.colors){
+                $scope.colors.threshold = {
+                    "values" :  $scope.colorThresholds
+                }
+            }
+        };
+        
         this.addColorFunction = function (colorFunction) {
             $scope.colorFunction = colorFunction;
         };


### PR DESCRIPTION
Example usage:
<c3chart ... >
       <chart-colors color-pattern="#FF0000,#fa5100,#F97600,#F6C600,#60B044" thresholds="30,60,80,99,100"></chart-colors>